### PR TITLE
GitHub Check report is now formatted as HTML instead of ASCII.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!--## Unreleased-->
-<!-- Add new, unreleased changes here. -->
+## Unreleased
+
+-   GitHub Check report is now formatted as HTML instead of ASCII.
+    <!-- Add new, unreleased changes here. -->
 
 ## [0.1.0] 2019-04-17
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -194,7 +194,7 @@ export function horizontalHtmlResultTable({dimensions, results}: ResultTable):
   const rows: string[] = [];
   for (const d of dimensions) {
     const cells = [
-      `<th>${d.label}</th>`,
+      `<th align="right">${d.label}</th>`,
       ...results.map((r) => `<td>${ansiCellToHtml(d.format(r))}</td>`),
     ];
     rows.push(`<tr>${cells.join('')}</tr>`);


### PR DESCRIPTION
Example of what's generated:

<table><tr><th align="right">Benchmark</th><td>shack</td></tr><tr><th align="right">Variant</th><td></td></tr><tr><th align="right">Impl</th><td>lit-html</td></tr><tr><th align="right">Version</th><td>default</td></tr><tr><th align="right">Sample size</th><td>2</td></tr><tr><th align="right">Bytes</th><td>110.36&nbsp;KiB</td></tr></table>
<table>
    <tr><th>Browser</th><th>Runtime [95% CI]</th><th>StdDev (CV)</th><th>Slowdown [95% CI]</th><th>Relative [95% CI]</th><th>Direction</th></tr>
    <tr><td>Chrome&nbsp;Headless&nbsp;74.0.3729.108</td><td>[4.336ms,&nbsp;21.299ms]</td><td>0.94ms&nbsp;(7%)</td><td>N/A&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td><td>N/A&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td><td>baseline</td></tr><tr><td>Firefox&nbsp;60.0</td><td>[-5.412ms,&nbsp;45.412ms]</td><td>2.83ms&nbsp;(14%)</td><td>[-19.608ms,&nbsp;+33.973ms]</td><td>[-167.50%,&nbsp;+279.57%]</td><td>unsure</td></tr>
  </table>