### PR TITLE
Support measuring First Contentful Paint (FCP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Added support for measuring First Contentful Paint (FCP), enabled by setting
+  the `--measure=fcp` flag.
+
 <!-- Add new, unreleased changes here. -->
 
 ## [0.2.0] 2019-04-25

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tachometer [![Build Status](https://travis-ci.com/PolymerLabs/tachometer.svg?token=Mh2qsyGY69vaxbRhosnZ&branch=master)](https://travis-ci.com/PolymerLabs/tachometer) [![NPM  package](https://img.shields.io/npm/v/tachometer.svg)](https://npmjs.org/package/tachometer)
 
-> tachometer is a tool for running both micro and first-paint benchmarks in
-> multiple web browsers. It uses repeated sampling and statistics to reliably
-> identify even the smallest differences in timing.
+> tachometer is a tool for running benchmarks in web browsers. It uses repeated
+> sampling and statistics to reliably identify even the smallest differences in
+> timing.
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tachometer [![Build Status](https://travis-ci.com/PolymerLabs/tachometer.svg?token=Mh2qsyGY69vaxbRhosnZ&branch=master)](https://travis-ci.com/PolymerLabs/tachometer) [![NPM  package](https://img.shields.io/npm/v/tachometer.svg)](https://npmjs.org/package/tachometer)
 
-> tachometer is a tool for running benchmarks in web browsers. It uses repeated
-sampling and statistics to reliably identify even the smallest differences in
-timing.
+> tachometer is a tool for running both micro and first-paint benchmarks in
+> multiple web browsers. It uses repeated sampling and statistics to reliably
+> identify even the smallest differences in timing.
 
 ## Why?
 
@@ -35,9 +35,10 @@ confidence in them.
   $ vim default/forloop/index.html
   ```
 
-3. Create a simple benchmark that just executes a for loop. tachometer
+3. Create a simple micro benchmark that just executes a for loop. tachometer
    benchmarks are just HTML files that import and call `bench.start()` and
-   `bench.stop()`.
+   `bench.stop()`. Note that when you are measuring [first contentful
+   paint](#first-contentful-paint-fcp), you don't need to call these functions.
 
   ```html
   <html>
@@ -89,6 +90,31 @@ much more.
 
 - *Automatically continue sampling* until we have enough precision to answer the
   question you are asking. See [auto sampling](#auto-sampling).
+
+## Measurement modes
+
+Tachometer currently supports two kinds of time interval measurements,
+controlled with the `--measure` flag.
+
+#### Callback
+
+By default, or when the `--measure` flag is set to **`callback`**, your page is
+responsible for calling the `start()` and `stop()` functions from the
+`/bench.js` module. This mode is appropriate for micro benchmarks, or any other
+kind of situation where you want full control over the beginning and end times.
+
+#### First Contentful Paint (FCP)
+
+When the `--measure` flag is set to **`fcp`**, then the [First Contentful Paint
+(FCP)](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)
+time will be automatically extracted from your page using the [Performance
+Timeline
+API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_Timeline).
+This interval begins at initial navigation, and ends when the browser first
+renders any DOM content. Currently, only Chrome supports the
+[`first-contentful-paint`](https://www.w3.org/TR/paint-timing/#first-contentful-paint)
+performance timeline entry. In this mode, calling the `start()` and `stop()`
+functions is not required, and has no effect.
 
 ## Average runtime
 
@@ -232,7 +258,7 @@ against: the GitHub master branch, a local development git clone, and the latest
 1.x version published to NPM:
 
 ```sh
-tachometer
+tach
 --package-version=lit-html/master=lit-html@github:Polymer/lit-html#master \
 --package-version=lit-html/local=lit-html@$HOME/lit-html \
 --package-version=lit-html/1.x=lit-html@^1.0.0
@@ -382,4 +408,4 @@ Flag                      | Default     | Description
 `--sample-size` / `-n`    | `50`        | Minimum number of times to run each benchmark ([details](#sample-size)]
 `--horizon`               | `10%`       | The degrees of difference to try and resolve when auto-sampling ("N%" or "Nms", comma-delimited) ([details](#auto-sampling))
 `--timeout`               | `3`         | The maximum number of minutes to spend auto-sampling ([details](#auto-sampling))
-`--measure`               | `callback`, `fcp` | Which time interval to measure
+`--measure`               | `callback`  | Which time interval to measure (`callback`, `fcp`) ([details](#measurement-modes))

--- a/README.md
+++ b/README.md
@@ -382,3 +382,4 @@ Flag                      | Default     | Description
 `--sample-size` / `-n`    | `50`        | Minimum number of times to run each benchmark ([details](#sample-size)]
 `--horizon`               | `10%`       | The degrees of difference to try and resolve when auto-sampling ("N%" or "Nms", comma-delimited) ([details](#auto-sampling))
 `--timeout`               | `3`         | The maximum number of minutes to spend auto-sampling ([details](#auto-sampling))
+`--measure`               | `callback`, `fcp` | Which time interval to measure

--- a/client/src/bench.ts
+++ b/client/src/bench.ts
@@ -35,7 +35,7 @@ export async function stop() {
     millis: runtime,
     urlPath: url.pathname,
   };
-  fetch('/callback', {
+  fetch('/submitResults', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/client/src/bench.ts
+++ b/client/src/bench.ts
@@ -20,16 +20,11 @@ interface BenchmarkResponse {
 const url = new URL(window.location.href);
 const runId = url.searchParams.get('runId') || undefined;
 const variant = url.searchParams.get('variant') || undefined;
-const paint = url.searchParams.has('paint');
 
 export const config = JSON.parse(url.searchParams.get('config') || '{}');
 
 let startTime: number;
 export function start() {
-  // This gives us a timestamp we can find in the performance logs to compute
-  // the interval between now and the end of the paint that may happen after
-  // bench.stop() is called.
-  console.timeStamp('benchStartCalled');
   startTime = performance.now();
 }
 
@@ -37,29 +32,17 @@ export async function stop() {
   const end = performance.now();
   const runtime = end - startTime;
   console.log('benchmark runtime', runtime, 'ms');
-
-  const send = async () => {
-    const response: BenchmarkResponse = {
-      runId,
-      variant,
-      millis: runtime,
-      urlPath: url.pathname,
-    };
-    fetch('/submitResults', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(response),
-    });
+  const response: BenchmarkResponse = {
+    runId,
+    variant,
+    millis: runtime,
+    urlPath: url.pathname,
   };
-
-  if (paint === true) {
-    // Wait two RAFs before we indicate that we're done, because if the code
-    // that just finished executing triggers a paint, it's probably going to
-    // paint on the next frame, and we want to see that in the performance logs.
-    requestAnimationFrame(() => requestAnimationFrame(() => send()));
-  } else {
-    send();
-  }
+  fetch('/submitResults', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(response),
+  });
 }

--- a/client/src/bench.ts
+++ b/client/src/bench.ts
@@ -11,14 +11,12 @@
 
 // Note: sync with runner/src/types.ts
 interface BenchmarkResponse {
-  runId?: string;
   urlPath: string;
   variant?: string;
   millis: number;
 }
 
 const url = new URL(window.location.href);
-const runId = url.searchParams.get('runId') || undefined;
 const variant = url.searchParams.get('variant') || undefined;
 
 export const config = JSON.parse(url.searchParams.get('config') || '{}');
@@ -33,12 +31,11 @@ export async function stop() {
   const runtime = end - startTime;
   console.log('benchmark runtime', runtime, 'ms');
   const response: BenchmarkResponse = {
-    runId,
     variant,
     millis: runtime,
     urlPath: url.pathname,
   };
-  fetch('/submitResults', {
+  fetch('/callback', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tachometer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,7 +117,7 @@ const optDefs: commandLineUsage.OptionDefinition[] = [
     name: 'measure',
     description: 'Which time interval to measure. Options:\n' +
         '- callback: bench.start() to bench.stop() (default)\n' +
-        '-      fcp: first contentful paint',
+        '- fcp: first contentful paint',
     type: String,
     defaultValue: 'callback',
   },
@@ -246,7 +246,7 @@ async function manualMode(opts: Opts, specs: BenchmarkSpec[], server: Server) {
   (async function() {
     while (true) {
       server.beginSession();
-      const result = await server.nextCallback();
+      const result = await server.nextResults();
       server.endSession();
       const resultStats = {result, stats: summaryStats(result.millis)};
       console.log(verticalTermResultTable(manualResultTable(resultStats)));
@@ -350,7 +350,7 @@ async function automaticMode(
       }
       millis = [fcp];
     } else {
-      const result = await server.nextCallback();
+      const result = await server.nextResults();
       millis = result.millis;
     }
     const {bytesSent, browser} = server.endSession();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,8 +116,8 @@ const optDefs: commandLineUsage.OptionDefinition[] = [
   {
     name: 'measure',
     description: 'Which time interval to measure. Options:\n' +
-        '- callback: bench.start() to bench.stop() (default)\n' +
-        '- fcp: first contentful paint',
+        'callback: bench.start() to bench.stop() (default)\n' +
+        'fcp: first contentful paint',
     type: String,
     defaultValue: 'callback',
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,8 +116,8 @@ const optDefs: commandLineUsage.OptionDefinition[] = [
   {
     name: 'measure',
     description: 'Which time interval to measure. Options:\n' +
-        'callback: bench.start() to bench.stop() (default)\n' +
-        'fcp: first contentful paint',
+        '* callback: bench.start() to bench.stop() (default)\n' +
+        '*      fcp: first contentful paint',
     type: String,
     defaultValue: 'callback',
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -123,9 +123,6 @@ export class Server {
     if (spec.config !== undefined) {
       params.config = JSON.stringify(spec.config);
     }
-    if (spec.paint === true) {
-      params.paint = 'true';
-    }
     return `${this.url}/benchmarks/${spec.implementation}/` +
         (spec.version.label === 'default' ? '' :
                                             `versions/${spec.version.label}/`) +
@@ -229,7 +226,6 @@ export class Server {
       implementation,
       version,
       millis: [response.millis],
-      paintMillis: [],  // This will come from the performance logs.
       browser: {
         name: browser.name || '',
         version: browser.version || '',

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -29,7 +29,6 @@ interface Opts {
   variant: string;
   browser: string;
   'package-version': string[];
-  paint: boolean;
 }
 
 /**
@@ -115,7 +114,6 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
                   version,
                   variant: variant.name || '',
                   config: variant.config || {},
-                  paint: opts.paint,
                 });
               }
             }
@@ -130,7 +128,6 @@ export async function specsFromOpts(opts: Opts): Promise<BenchmarkSpec[]> {
               version,
               variant: '',
               config: {},
-              paint: opts.paint,
             });
           }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,14 +65,12 @@ export interface BenchmarkSpec {
 
 // Note: sync with client/src/index.ts
 export interface BenchmarkResponse {
-  runId?: string;
   urlPath: string;
   variant?: string;
   millis: number;
 }
 
 export interface BenchmarkResult {
-  runId: string|undefined;
   name: string;
   implementation: string;
   version: string;
@@ -80,12 +78,6 @@ export interface BenchmarkResult {
   millis: number[];
   browser: {name: string, version: string};
   bytesSent: number;
-}
-
-export interface PendingBenchmark {
-  id: string;
-  spec: BenchmarkSpec;
-  deferred: Deferred<BenchmarkResult>;
 }
 
 export interface BenchmarkSession {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,6 @@ export interface BenchmarkSpec {
   variant: string;
   browser: string;
   config: {};
-  paint: boolean;
 }
 
 // Note: sync with client/src/index.ts
@@ -78,11 +77,7 @@ export interface BenchmarkResult {
   implementation: string;
   version: string;
   variant: string;
-  // Millisecond interval between bench.start() and bench.stop().
   millis: number[];
-  // Millisecond interval between bench.start() and the end of the first paint
-  // which occurs after bench.stop()
-  paintMillis: number[];
   browser: {name: string, version: string};
   bytesSent: number;
 }


### PR DESCRIPTION
- Adds `--measure=fcp` flag which measures [First Contentful Paint](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint) time. This works by calling the [Performance Timeline API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_Timeline) from webdriver. These paint events are currently only available in Chrome.
- In this mode, you don't need to call `bench.start()` and `bench.stop()` anymore (you can, but it will have no effect).
- Removed the `--paint` flag (which wasn't really documented), since this supersedes it. Since this works by calling a client script, we don't actually need to use Chrome logs at all.
- Also includes some refactoring relating to the fact that we previously always assumed that we'd be getting a callback from the page. We now only assume that when we're in `--measure=callback` mode (the original behavior, still the default).
