### PR TITLE
Replace variants with querystrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 -   Benchmark names can now include URL query strings (e.g. `tach
     my-benchmark?foo=1&baz=2`) which will be included as-is in the launched URL.
 
+-   Variants no longer exist. Use URL query strings intead (see above).
+
 -   `--manual` mode no longer shows benchmark data (but it should only be used
     for testing the web server anyway since it has no statistical significance).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
-<!-- Add new, unreleased changes here. -->
+## Unreleased
+
+-   `--manual` mode no longer shows benchmark data (but it should only be used
+    for testing the web server anyway since it has no statistical significance).
 
 -   Add `--version` flag.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+-   Benchmark names can now include URL query strings (e.g. `tach
+    my-benchmark?foo=1&baz=2`) which will be included as-is in the launched URL.
+
 -   `--manual` mode no longer shows benchmark data (but it should only be used
     for testing the web server anyway since it has no statistical significance).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
 
+-   Add `--version` flag.
+
 ## [0.3.0] 2019-05-03
 
 -   Full URLs are now supported (e.g. `tach http://example.com`). Only

--- a/README.md
+++ b/README.md
@@ -83,11 +83,6 @@ much more.
   regressions. See [package versions](#package-versions).
 
 
-- *Configure variants* of a benchmark from the command-line. For example we
-  can make the number of iterations in the example above a parameter so that
-  it can be configured from a JSON config file. See [variants](#variants).
-
-
 - *Automatically continue sampling* until we have enough precision to answer the
   question you are asking. See [auto sampling](#auto-sampling).
 
@@ -176,60 +171,6 @@ create a `default` (or any name) directory with no `package.json`.
 
 Finally, each **benchmark** directory contains a benchmark. Each benchmark
 directory must have an `index.html` file, which is what tachometer will launch.
-
-## Variants
-
-We often want to compare multiple versions of the same benchmark implementation,
-but with different configuration parameters. For example, we might want to see
-how the performance of some function scales with 1, 100, and 1000 invocations.
-Instead of writing a new benchmark for each of these numbers, we can instead use
-a configuration file to define ***variants***.
-
-If a `benchmarks.json` file is found in a `<benchmark>` directory, then it will
-be read to look for a list of variants in the following format:
-
-Field             | Description
-------------------| -------------------------------
-`variants`        | A list of variant objects for this benchmark
-`variants.name`   | A label for this variant for use on the command-line
-`variants.config` | An arbitrary object which will be passed to the benchmark function as `bench.config`
-
-For example, we might have this `benchmarks.json`:
-
-```js
-{
-  "variants": [
-    {
-      "name": "small",
-      "config": {
-        "iterations": 1
-      }
-    },
-    {
-      "name": "medium",
-      "config": {
-        "iterations": 100
-      }
-    },
-    {
-      "name": "large",
-      "config": {
-        "iterations": 1000
-      }
-    }
-  ]
-}
-```
-
-With an implementation like this:
-
-```js
-bench.start();
-for (let i = 0; i < bench.config.iterations; i++) {
-  doSomething();
-}
-bench.stop();
-```
 
 ## Package Versions
 
@@ -409,7 +350,6 @@ Flag                      | Default     | Description
 `--host`                  | `127.0.0.1` | Which host to run on
 `--port`                  | `8080, 8081, ..., 0`| Which port to run on (comma-delimited preference list, `0` for random)
 `--implementation` / `-i` | `*`         | Which implementations to run (`*` for all) ([details](#folder-layout))
-`--variant` / `-v`        | `*`         | Which variants to run (`*` for all) ([details](#variants))
 `--package-version` / `-p`| *(none)*    | Specify one or more dependency versions ([details](#package-versions))
 `--browser` / `-b`        | `chrome`    | Which browsers to launch in automatic mode, comma-delimited (chrome, chrome-headless, firefox, firefox-headless, safari)
 `--sample-size` / `-n`    | `50`        | Minimum number of times to run each benchmark ([details](#sample-size)]

--- a/client/src/bench.ts
+++ b/client/src/bench.ts
@@ -11,13 +11,10 @@
 
 // Note: sync with runner/src/types.ts
 interface BenchmarkResponse {
-  urlPath: string;
-  variant?: string;
   millis: number;
 }
 
 const url = new URL(window.location.href);
-const variant = url.searchParams.get('variant') || undefined;
 
 export const config = JSON.parse(url.searchParams.get('config') || '{}');
 
@@ -31,9 +28,7 @@ export async function stop() {
   const runtime = end - startTime;
   console.log('benchmark runtime', runtime, 'ms');
   const response: BenchmarkResponse = {
-    variant,
     millis: runtime,
-    urlPath: url.pathname,
   };
   fetch('/submitResults', {
     method: 'POST',

--- a/client/src/bench.ts
+++ b/client/src/bench.ts
@@ -14,10 +14,6 @@ interface BenchmarkResponse {
   millis: number;
 }
 
-const url = new URL(window.location.href);
-
-export const config = JSON.parse(url.searchParams.get('config') || '{}');
-
 let startTime: number;
 export function start() {
   startTime = performance.now();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ import {AutomaticResults, verticalTermResultTable, horizontalTermResultTable, ve
 import {prepareVersionDirectories} from './versions';
 import * as github from './github';
 
-const optDefs: commandLineUsage.OptionDefinition[] = [
+export const optDefs: commandLineUsage.OptionDefinition[] = [
   {
     name: 'help',
     description: 'Show documentation',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,13 +71,6 @@ export const optDefs: commandLineUsage.OptionDefinition[] = [
     defaultValue: '*',
   },
   {
-    name: 'variant',
-    description: 'Which variant to run (* for all)',
-    alias: 'v',
-    type: String,
-    defaultValue: '*',
-  },
-  {
     name: 'package-version',
     description: 'Specify one or more dependency versions (see README)',
     alias: 'p',
@@ -153,7 +146,6 @@ export interface Opts {
   host: string;
   port: number[];
   implementation: string;
-  variant: string;
   'package-version': string[];
   browser: string;
   'sample-size': number;
@@ -269,7 +261,7 @@ async function manualMode(opts: Opts, specs: BenchmarkSpec[], server: Server) {
   for (const spec of specs) {
     console.log();
     console.log(
-        `${spec.name} ${spec.variant} ` +
+        `${spec.name}${spec.queryString} ` +
         `/ ${spec.implementation} ${spec.version.label}`);
     const url = spec.url !== undefined ? spec.url : server.specUrl(spec);
     console.log(ansi.format(`[yellow]{${url}}`));
@@ -394,7 +386,6 @@ async function automaticMode(
         queryString: spec.queryString,
         implementation: spec.implementation,
         version: spec.version.label,
-        variant: spec.variant,
         millis,
         bytesSent,
         browser,
@@ -417,8 +408,7 @@ async function automaticMode(
         status: [
           `${++run}/${numRuns}`,
           spec.browser,
-          spec.name,
-          spec.variant,
+          spec.name + spec.queryString,
           `${spec.implementation}@${spec.version.label}`,
         ].filter((part) => part !== '')
                     .join(' '),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -391,6 +391,7 @@ async function automaticMode(
     if (millis !== undefined) {
       const result = {
         name: spec.name,
+        queryString: spec.queryString,
         implementation: spec.implementation,
         version: spec.version.label,
         variant: spec.variant,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@
 require('source-map-support').install();
 
 import * as fsExtra from 'fs-extra';
+import * as path from 'path';
 import * as webdriver from 'selenium-webdriver';
 
 import commandLineArgs = require('command-line-args');
@@ -33,6 +34,12 @@ export const optDefs: commandLineUsage.OptionDefinition[] = [
   {
     name: 'help',
     description: 'Show documentation',
+    type: Boolean,
+    defaultValue: false,
+  },
+  {
+    name: 'version',
+    description: 'Show the installed version of tachometer',
     type: Boolean,
     defaultValue: false,
   },
@@ -141,6 +148,7 @@ export const optDefs: commandLineUsage.OptionDefinition[] = [
 
 export interface Opts {
   help: boolean;
+  version: boolean;
   root: string;
   host: string;
   port: number[];
@@ -177,13 +185,17 @@ function combineResults(results: BenchmarkResult[]): BenchmarkResult {
   return combined;
 }
 
+const getVersion = (): string =>
+    require(path.join(__dirname, '..', 'package.json')).version;
+
 export async function main() {
   const opts = commandLineArgs(optDefs, {partial: true}) as Opts;
+
   if (opts.help) {
     console.log(commandLineUsage([
       {
         header: 'tach',
-        content: 'https://github.com/PolymerLabs/tachometer',
+        content: `v${getVersion()}\nhttps://github.com/PolymerLabs/tachometer`,
       },
       {
         header: 'Usage',
@@ -196,6 +208,11 @@ export async function main() {
         optionList: optDefs,
       },
     ]));
+    return;
+  }
+
+  if (opts.version) {
+    console.log(getVersion());
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ import {BenchmarkResult, BenchmarkSpec, Measurement} from './types';
 import {Server} from './server';
 import {Horizons, ResultStats, horizonsResolved, summaryStats, computeDifferences} from './stats';
 import {specsFromOpts} from './specs';
-import {AutomaticResults, verticalTermResultTable, horizontalTermResultTable, verticalHtmlResultTable, horizontalHtmlResultTable, automaticResultTable, manualResultTable, spinner} from './format';
+import {AutomaticResults, verticalTermResultTable, horizontalTermResultTable, verticalHtmlResultTable, horizontalHtmlResultTable, automaticResultTable, spinner} from './format';
 import {prepareVersionDirectories} from './versions';
 import * as github from './github';
 
@@ -280,8 +280,7 @@ async function manualMode(opts: Opts, specs: BenchmarkSpec[], server: Server) {
       server.beginSession();
       const result = await server.nextResults();
       server.endSession();
-      const resultStats = {result, stats: summaryStats(result.millis)};
-      console.log(verticalTermResultTable(manualResultTable(resultStats)));
+      console.log(`${result.millis.toFixed(3)} ms`);
     }
   })();
 }
@@ -386,7 +385,7 @@ async function automaticMode(
       }
     } else {
       const result = await server.nextResults();
-      millis = result.millis;
+      millis = [result.millis];
     }
     const {bytesSent, browser} = server.endSession();
     if (millis !== undefined) {

--- a/src/format.ts
+++ b/src/format.ts
@@ -34,22 +34,6 @@ export interface ResultTable {
   results: ResultStats[];
 }
 
-/**
- * Create a manual mode result table.
- */
-export function manualResultTable(result: ResultStats): ResultTable {
-  const dimensions = [
-    benchmarkDimension,
-    variantDimension,
-    implementationDimension,
-    versionDimension,
-    browserDimension,
-    bytesSentDimension,
-    runtimePointEstimateDimension,
-  ];
-  return {dimensions, results: [result]};
-}
-
 export interface AutomaticResults {
   fixed: ResultTable;
   unfixed: ResultTable;
@@ -292,12 +276,6 @@ const runtimeConfidenceIntervalDimension: Dimension = {
   },
   format: (r: ResultStats) =>
       formatConfidenceInterval(r.stats.meanCI, (n) => n.toFixed(2) + 'ms'),
-};
-
-const runtimePointEstimateDimension: Dimension = {
-  label: 'Runtime',
-  format: (r: ResultStats) =>
-      ansi.format(`[blue]{${r.stats.mean.toFixed(3)}} ms`),
 };
 
 function formatDifference({absolute, relative}: Difference): string {

--- a/src/format.ts
+++ b/src/format.ts
@@ -53,7 +53,6 @@ export function automaticResultTable(results: ResultStats[]): AutomaticResults {
   const possiblyFixed = [
     benchmarkDimension,
     queryParamsDimension,
-    variantDimension,
     implementationDimension,
     versionDimension,
     browserDimension,
@@ -245,14 +244,6 @@ const queryParamsDimension: Dimension = {
       r.result.queryString || ansi.format('[gray]{<none>}'),
 };
 
-const variantDimension: Dimension = {
-  label: 'Variant',
-  tableConfig: {
-    alignment: 'right',
-  },
-  format: (r: ResultStats) => r.result.variant,
-};
-
 const implementationDimension: Dimension = {
   label: 'Impl',
   format: (r: ResultStats) => r.result.implementation,
@@ -323,14 +314,12 @@ function percent(n: number): string {
 function makeUniqueLabelFn(results: BenchmarkResult[]):
     (result: BenchmarkResult) => string {
   const names = new Set();
-  const variants = new Set();
   const queryStrings = new Set();
   const implementations = new Set();
   const versions = new Set();
   const browsers = new Set();
   for (const result of results) {
     names.add(result.name);
-    variants.add(result.variant);
     queryStrings.add(result.queryString);
     implementations.add(result.implementation);
     versions.add(result.version);
@@ -340,9 +329,6 @@ function makeUniqueLabelFn(results: BenchmarkResult[]):
     const fields = [];
     if (names.size > 1) {
       fields.push(result.name);
-    }
-    if (variants.size > 1) {
-      fields.push(result.variant);
     }
     if (queryStrings.size > 1) {
       fields.push(result.queryString || '<none>');

--- a/src/format.ts
+++ b/src/format.ts
@@ -52,6 +52,7 @@ export function automaticResultTable(results: ResultStats[]): AutomaticResults {
 
   const possiblyFixed = [
     benchmarkDimension,
+    queryParamsDimension,
     variantDimension,
     implementationDimension,
     versionDimension,
@@ -235,6 +236,15 @@ const benchmarkDimension: Dimension = {
   format: (r: ResultStats) => r.result.name,
 };
 
+const queryParamsDimension: Dimension = {
+  label: 'Params',
+  tableConfig: {
+    alignment: 'right',
+  },
+  format: (r: ResultStats) =>
+      r.result.queryString || ansi.format('[gray]{<none>}'),
+};
+
 const variantDimension: Dimension = {
   label: 'Variant',
   tableConfig: {
@@ -314,12 +324,14 @@ function makeUniqueLabelFn(results: BenchmarkResult[]):
     (result: BenchmarkResult) => string {
   const names = new Set();
   const variants = new Set();
+  const queryStrings = new Set();
   const implementations = new Set();
   const versions = new Set();
   const browsers = new Set();
   for (const result of results) {
     names.add(result.name);
     variants.add(result.variant);
+    queryStrings.add(result.queryString);
     implementations.add(result.implementation);
     versions.add(result.version);
     browsers.add(result.browser.name);
@@ -331,6 +343,9 @@ function makeUniqueLabelFn(results: BenchmarkResult[]):
     }
     if (variants.size > 1) {
       fields.push(result.variant);
+    }
+    if (queryStrings.size > 1) {
+      fields.push(result.queryString || '<none>');
     }
     if (implementations.size > 1) {
       fields.push(result.implementation);

--- a/src/server.ts
+++ b/src/server.ts
@@ -120,16 +120,10 @@ export class Server {
   }
 
   specUrl(spec: BenchmarkSpec): string {
-    let queryString = '';
-    if (spec.config !== undefined && Object.keys(spec.config).length > 0) {
-      queryString = '?config=' + JSON.stringify(spec.config);
-    } else if (spec.queryString) {
-      queryString = spec.queryString;
-    }
     return `${this.url}/benchmarks/${spec.implementation}/` +
         (spec.version.label === 'default' ? '' :
                                             `versions/${spec.version.label}/`) +
-        `${spec.name}/${queryString}`;
+        `${spec.name}/${spec.queryString}`;
   }
 
   async nextResults(): Promise<BenchmarkResponse> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -123,6 +123,8 @@ export class Server {
     let queryString = '';
     if (spec.config !== undefined && Object.keys(spec.config).length > 0) {
       queryString = '?config=' + JSON.stringify(spec.config);
+    } else if (spec.queryString) {
+      queryString = spec.queryString;
     }
     return `${this.url}/benchmarks/${spec.implementation}/` +
         (spec.version.label === 'default' ? '' :

--- a/src/test/specs_test.ts
+++ b/src/test/specs_test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+
+import {optDefs, Opts} from '../cli';
+import {specsFromOpts} from '../specs';
+
+import commandLineArgs = require('command-line-args');
+
+const parse = (argv: string[]) =>
+    commandLineArgs(optDefs, {argv, partial: true}) as Opts;
+
+suite('specsFromOpts', () => {
+  test('nothing', async () => {
+    const specs = await specsFromOpts(parse([]));
+    assert.deepEqual(specs, []);
+  });
+
+  test('url', async () => {
+    const argv = ['http://example.com'];
+    const specs = await specsFromOpts(parse(argv));
+    assert.deepEqual(specs, [
+      {
+        browser: 'chrome',
+        config: {},
+        implementation: 'default',
+        measurement: 'fcp',
+        name: 'http://example.com',
+        url: 'http://example.com',
+        variant: '',
+        version: {
+          dependencyOverrides: {},
+          label: '',
+        }
+      },
+    ]);
+  });
+});

--- a/src/test/specs_test.ts
+++ b/src/test/specs_test.ts
@@ -35,6 +35,7 @@ suite('specsFromOpts', () => {
         implementation: 'default',
         measurement: 'fcp',
         name: 'http://example.com',
+        queryString: '',
         url: 'http://example.com',
         variant: '',
         version: {

--- a/src/test/specs_test.ts
+++ b/src/test/specs_test.ts
@@ -31,13 +31,11 @@ suite('specsFromOpts', () => {
     assert.deepEqual(specs, [
       {
         browser: 'chrome',
-        config: {},
         implementation: 'default',
         measurement: 'fcp',
         name: 'http://example.com',
         queryString: '',
         url: 'http://example.com',
-        variant: '',
         version: {
           dependencyOverrides: {},
           label: '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,8 +70,6 @@ export interface BenchmarkSpec {
 
 // Note: sync with client/src/index.ts
 export interface BenchmarkResponse {
-  urlPath: string;
-  variant?: string;
   millis: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,14 +22,6 @@ export class Deferred<T> {
   }
 }
 
-/** The expected format of a benchmarks.json configuration file. */
-export interface ConfigFormat {
-  variants?: Array<{
-    name?: string,
-    config?: {},
-  }>;
-}
-
 /**
  * A mapping from NPM package name to version specifier, as used in a
  * package.json's "dependencies" and "devDependencies".
@@ -64,9 +56,7 @@ export interface BenchmarkSpec {
   queryString: string;
   implementation: string;
   version: PackageVersion;
-  variant: string;
   browser: string;
-  config: {};
 }
 
 // Note: sync with client/src/index.ts
@@ -79,7 +69,6 @@ export interface BenchmarkResult {
   queryString: string;
   implementation: string;
   version: string;
-  variant: string;
   millis: number[];
   browser: {name: string, version: string};
   bytesSent: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export interface BenchmarkSpec {
   url?: string;
   measurement: Measurement;
   name: string;
+  queryString: string;
   implementation: string;
   version: PackageVersion;
   variant: string;
@@ -75,6 +76,7 @@ export interface BenchmarkResponse {
 
 export interface BenchmarkResult {
   name: string;
+  queryString: string;
   implementation: string;
   version: string;
   variant: string;


### PR DESCRIPTION
- Entirely removes the notion of variants. Instead, you can now specify query params when specifying the benchmarks to run (e.g. `tach my-benchmark?foo=bar`).

- Remove a bunch of information from `--manual` mode output. This added a bunch of complexity, since in manual mode we don't know in advance which benchmark we're running, so we had to pass and receive more information to the browser so that we can figure that out when a result comes in. But it's not worth it, since manual mode should have very limited usage anyway, since it offers no statistical significance.

- Add `--version` flag (fixes https://github.com/PolymerLabs/tachometer/issues/33)

- Add a little more unit test coverage (more in a future PR).