### PR TITLE
Prepare for dropping file layout requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Variants no longer exist. Use URL query strings intead (see above).
 
+-   Custom package versions are now installed to the system's temp dir, instead
+    of into the project directory.
+
 -   `--manual` mode no longer shows benchmark data (but it should only be used
     for testing the web server anyway since it has no statistical significance).
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,13 @@ export const optDefs: commandLineUsage.OptionDefinition[] = [
     lazyMultiple: true,
   },
   {
+    name: 'npm-install-dir',
+    description: `Where to install custom package versions ` +
+        `(default ${defaultInstallDir})`,
+    type: String,
+    defaultValue: defaultInstallDir,
+  },
+  {
     name: 'browser',
     description: 'Which browsers to launch in automatic mode, ' +
         `comma-delimited (${[...validBrowsers].join(', ')})`,
@@ -150,6 +157,7 @@ export interface Opts {
   port: number[];
   implementation: string;
   'package-version': string[];
+  'npm-install-dir': string;
   browser: string;
   'sample-size': number;
   manual: boolean;
@@ -236,7 +244,8 @@ export async function main() {
     }
   }
 
-  const plans = await makeServerPlans(opts.root, specs);
+  const plans =
+      await makeServerPlans(opts.root, opts['npm-install-dir'], specs);
 
   for (const plan of plans) {
     for (const install of plan.npmInstalls) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ require('source-map-support').install();
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import * as webdriver from 'selenium-webdriver';
+import * as os from 'os';
 
 import commandLineArgs = require('command-line-args');
 import commandLineUsage = require('command-line-usage');
@@ -27,8 +28,10 @@ import {Server} from './server';
 import {Horizons, ResultStats, horizonsResolved, summaryStats, computeDifferences} from './stats';
 import {specsFromOpts} from './specs';
 import {AutomaticResults, verticalTermResultTable, horizontalTermResultTable, verticalHtmlResultTable, horizontalHtmlResultTable, automaticResultTable, spinner} from './format';
-import {prepareVersionDirectories} from './versions';
+import {prepareVersionDirectory, makeServerPlans} from './versions';
 import * as github from './github';
+
+const defaultInstallDir = path.join(os.tmpdir(), 'tachometer', 'versions');
 
 export const optDefs: commandLineUsage.OptionDefinition[] = [
   {
@@ -233,46 +236,80 @@ export async function main() {
     }
   }
 
-  await prepareVersionDirectories(opts.root, specs);
+  const plans = await makeServerPlans(opts.root, specs);
 
-  const server = await Server.start({
-    host: opts.host,
-    ports: opts.port,
-    benchmarksDir: opts.root,
-  });
+  for (const plan of plans) {
+    for (const install of plan.npmInstalls) {
+      await prepareVersionDirectory(install);
+    }
+  }
+
+  const servers = new Map<BenchmarkSpec, Server>();
+  for (const {specs, mountPoints} of plans) {
+    const server = await Server.start({
+      host: opts.host,
+      ports: opts.port,
+      benchmarksDir: opts.root,
+      mountPoints,
+    });
+    for (const spec of specs) {
+      servers.set(spec, server);
+    }
+  }
 
   if (opts.manual === true) {
-    await manualMode(opts, specs, server);
+    await manualMode(opts, specs, servers);
   } else {
-    await automaticMode(opts, specs, server);
+    await automaticMode(opts, specs, servers);
   }
 }
+
+type ServerMap = Map<BenchmarkSpec, Server>;
 
 /**
  * Let the user run benchmarks manually. This process will not exit until
  * the user sends a termination signal.
  */
-async function manualMode(opts: Opts, specs: BenchmarkSpec[], server: Server) {
+async function manualMode(
+    opts: Opts, specs: BenchmarkSpec[], servers: ServerMap) {
   if (opts.save) {
     throw new Error(`Can't save results in manual mode`);
   }
 
-  console.log('Visit these URLs in any browser:');
+  console.log('\nVisit these URLs in any browser:');
+  const allServers = new Set<Server>([...servers.values()]);
   for (const spec of specs) {
+    let url;
+    if (spec.url !== undefined) {
+      url = spec.url;
+    } else {
+      const server = servers.get(spec);
+      if (server === undefined) {
+        throw new Error('Internal error: no server for spec');
+      }
+      url = server.specUrl(spec);
+    }
+
     console.log();
     console.log(
         `${spec.name}${spec.queryString} ` +
         `/ ${spec.implementation} ${spec.version.label}`);
-    const url = spec.url !== undefined ? spec.url : server.specUrl(spec);
     console.log(ansi.format(`[yellow]{${url}}`));
   }
+
   console.log(`\nResults will appear below:\n`);
   (async function() {
     while (true) {
-      server.beginSession();
-      const result = await server.nextResults();
-      server.endSession();
+      const resultPromises = [];
+      for (const server of allServers) {
+        server.beginSession();
+        resultPromises.push(server.nextResults());
+      }
+      const result = await Promise.race(resultPromises);
       console.log(`${result.millis.toFixed(3)} ms`);
+      for (const server of allServers) {
+        server.endSession();
+      }
     }
   })();
 }
@@ -284,7 +321,7 @@ interface Browser {
 }
 
 async function automaticMode(
-    opts: Opts, specs: BenchmarkSpec[], server: Server) {
+    opts: Opts, specs: BenchmarkSpec[], servers: ServerMap) {
   const horizons = parseHorizonFlag(opts.horizon);
 
   let reportGitHubCheckResults;
@@ -352,14 +389,27 @@ async function automaticMode(
     browsers.set(browser, {name: browser, driver, initialTabHandle});
   }
 
+  const allServers = new Set<Server>([...servers.values()]);
   const specResults = new Map<BenchmarkSpec, BenchmarkResult[]>();
   for (const spec of specs) {
     specResults.set(spec, []);
   }
 
+
   const runSpec = async (spec: BenchmarkSpec) => {
-    server.beginSession();
-    const url = spec.url !== undefined ? spec.url : server.specUrl(spec);
+    let server;
+    let url;
+    if (spec.url !== undefined) {
+      url = spec.url;
+    } else {
+      server = servers.get(spec);
+      if (server === undefined) {
+        throw new Error('Internal error: no server for spec');
+      }
+      url = server.specUrl(spec);
+      server.beginSession();
+    }
+
     const {driver, initialTabHandle} = browsers.get(spec.browser)!;
     await openAndSwitchToNewTab(driver);
     await driver.get(url);
@@ -376,11 +426,20 @@ async function automaticMode(
             `Timed out waiting for first contentful paint from ${url}`);
       }
     } else {
+      if (server === undefined) {
+        throw new Error('Internal error: no server for spec');
+      }
       const result = await server.nextResults();
       millis = [result.millis];
     }
-    const {bytesSent, browser} = server.endSession();
     if (millis !== undefined) {
+      let bytesSent = 0;
+      let browser = {name: '', version: ''};
+      if (server !== undefined) {
+        const session = server.endSession();
+        bytesSent = session.bytesSent;
+        browser = session.browser;
+      }
       const result = {
         name: spec.name,
         queryString: spec.queryString,
@@ -468,7 +527,7 @@ async function automaticMode(
 
   // Close the browsers by closing each of their last remaining tabs.
   await Promise.all([...browsers.values()].map(({driver}) => driver.close()));
-  await server.close();
+  await Promise.all([...allServers].map((server) => server.close()));
 
   const withDifferences = makeResults();
   console.log();

--- a/src/test/data/mylib/package.json
+++ b/src/test/data/mylib/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "mylib": "0.0.0",
+    "otherlib": "0.0.0"
+  }
+}

--- a/src/test/versions_test.ts
+++ b/src/test/versions_test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as path from 'path';
+
+import {BenchmarkSpec} from '../types';
+import {makeServerPlans, ServerPlan} from '../versions';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const testData = path.resolve(repoRoot, 'src', 'test', 'data');
+
+suite('versions', () => {
+  test('makeServerPlans', async () => {
+    const specs: BenchmarkSpec[] = [
+      // mybench running with two custom versions.
+      {
+        name: 'mybench',
+        implementation: 'mylib',
+        version: {
+          label: 'v1',
+          dependencyOverrides: {
+            mylib: '1.0.0',
+          },
+        },
+        measurement: 'fcp',
+        queryString: '',
+        browser: 'chrome',
+      },
+      {
+        name: 'mybench',
+        implementation: 'mylib',
+        version: {
+          label: 'v2',
+          dependencyOverrides: {
+            mylib: '2.0.0',
+          },
+        },
+        measurement: 'fcp',
+        queryString: '',
+        browser: 'chrome',
+      },
+
+      // mybench and other bench only need the default server.
+      {
+        name: 'mybench',
+        implementation: 'mylib',
+        version: {
+          label: 'default',
+          dependencyOverrides: {},
+        },
+        measurement: 'fcp',
+        queryString: '',
+        browser: 'chrome',
+      },
+      {
+        name: 'otherbench',
+        implementation: 'otherlib',
+        version: {
+          label: 'default',
+          dependencyOverrides: {},
+        },
+        measurement: 'fcp',
+        queryString: '',
+        browser: 'chrome',
+      },
+
+      // A remote URL doesn't need a server.
+      {
+        name: 'http://example.com',
+        url: 'http://example.com',
+        implementation: '',
+        version: {
+          label: '',
+          dependencyOverrides: {},
+        },
+        measurement: 'fcp',
+        queryString: '',
+        browser: 'chrome',
+      },
+    ];
+
+    const actual = await makeServerPlans(testData, specs);
+
+    const expected: ServerPlan[] = [
+      {
+        specs: [specs[2], specs[3]],
+        npmInstalls: [],
+        mountPoints: [],
+      },
+
+      {
+        specs: [specs[0]],
+        npmInstalls: [{
+          installDir: path.join(testData, 'mylib', 'versions', 'v1'),
+          packageJson: {
+            private: true,
+            dependencies: {
+              mylib: '1.0.0',
+              otherlib: '0.0.0',
+            },
+          },
+        }],
+        mountPoints: [
+          {
+            diskPath:
+                path.join(testData, 'mylib', 'versions', 'v1', 'node_modules'),
+            urlPath: '/benchmarks/mylib/versions/v1/node_modules',
+          },
+          {
+            diskPath: path.join(testData, 'mylib'),
+            urlPath: '/benchmarks/mylib/versions/v1',
+          },
+        ],
+      },
+
+      {
+        specs: [specs[1]],
+        npmInstalls: [{
+          installDir: path.join(testData, 'mylib', 'versions', 'v2'),
+          packageJson: {
+            private: true,
+            dependencies: {
+              mylib: '2.0.0',
+              otherlib: '0.0.0',
+            },
+          },
+        }],
+        mountPoints: [
+          {
+            diskPath:
+                path.join(testData, 'mylib', 'versions', 'v2', 'node_modules'),
+            urlPath: '/benchmarks/mylib/versions/v2/node_modules',
+          },
+          {
+            diskPath: path.join(testData, 'mylib'),
+            urlPath: '/benchmarks/mylib/versions/v2',
+          },
+        ],
+      },
+    ];
+
+    assert.deepEqual(actual, expected);
+  });
+});

--- a/src/test/versions_test.ts
+++ b/src/test/versions_test.ts
@@ -13,7 +13,7 @@ import {assert} from 'chai';
 import * as path from 'path';
 
 import {BenchmarkSpec} from '../types';
-import {makeServerPlans, ServerPlan} from '../versions';
+import {hashStrings, makeServerPlans, ServerPlan} from '../versions';
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 const testData = path.resolve(repoRoot, 'src', 'test', 'data');
@@ -88,7 +88,11 @@ suite('versions', () => {
       },
     ];
 
-    const actual = await makeServerPlans(testData, specs);
+    const tempDir = '/tmp';
+    const actual = await makeServerPlans(testData, tempDir, specs);
+
+    const v1Hash = hashStrings(path.join(testData, 'mylib'), 'v1');
+    const v2Hash = hashStrings(path.join(testData, 'mylib'), 'v2');
 
     const expected: ServerPlan[] = [
       {
@@ -100,7 +104,7 @@ suite('versions', () => {
       {
         specs: [specs[0]],
         npmInstalls: [{
-          installDir: path.join(testData, 'mylib', 'versions', 'v1'),
+          installDir: path.join(tempDir, v1Hash),
           packageJson: {
             private: true,
             dependencies: {
@@ -111,8 +115,7 @@ suite('versions', () => {
         }],
         mountPoints: [
           {
-            diskPath:
-                path.join(testData, 'mylib', 'versions', 'v1', 'node_modules'),
+            diskPath: path.join(tempDir, v1Hash, 'node_modules'),
             urlPath: '/benchmarks/mylib/versions/v1/node_modules',
           },
           {
@@ -125,7 +128,7 @@ suite('versions', () => {
       {
         specs: [specs[1]],
         npmInstalls: [{
-          installDir: path.join(testData, 'mylib', 'versions', 'v2'),
+          installDir: path.join(tempDir, v2Hash),
           packageJson: {
             private: true,
             dependencies: {
@@ -136,8 +139,7 @@ suite('versions', () => {
         }],
         mountPoints: [
           {
-            diskPath:
-                path.join(testData, 'mylib', 'versions', 'v2', 'node_modules'),
+            diskPath: path.join(tempDir, v2Hash, 'node_modules'),
             urlPath: '/benchmarks/mylib/versions/v2/node_modules',
           },
           {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface PackageVersion {
 
 /** The subset of the format of an NPM package.json file we care about. */
 export interface NpmPackageJson {
-  name: string;
+  private: boolean;
   dependencies: PackageDependencyMap;
 }
 

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -10,6 +10,7 @@
  */
 
 import * as child_process from 'child_process';
+import * as crypto from 'crypto';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 
@@ -83,7 +84,8 @@ export interface NpmInstall {
 }
 
 export async function makeServerPlans(
-    benchmarkRoot: string, specs: BenchmarkSpec[]): Promise<ServerPlan[]> {
+    benchmarkRoot: string, npmInstallRoot: string, specs: BenchmarkSpec[]):
+    Promise<ServerPlan[]> {
   const keySpecs = new Map<string, BenchmarkSpec[]>();
   const keyDeps = new Map<string, PackageDependencyMap>();
   const defaultSpecs = [];
@@ -134,7 +136,8 @@ export async function makeServerPlans(
 
     const originalPackageDir = path.join(benchmarkRoot, implementation);
 
-    const installDir = path.join(originalPackageDir, 'versions', label);
+    const installDir =
+        path.join(npmInstallRoot, hashStrings(originalPackageDir, label));
     plans.push({
       specs,
       npmInstalls: [{
@@ -159,6 +162,12 @@ export async function makeServerPlans(
   }
 
   return plans;
+}
+
+export function hashStrings(...strings: string[]) {
+  return crypto.createHash('sha256')
+      .update(JSON.stringify(strings))
+      .digest('hex');
 }
 
 /**

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -13,6 +13,7 @@ import * as child_process from 'child_process';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 
+import {MountPoint} from './server';
 import {BenchmarkSpec, NpmPackageJson, PackageDependencyMap, PackageVersion} from './types';
 
 /**
@@ -67,20 +68,97 @@ export function parsePackageVersions(flags: string[]):
   return versions;
 }
 
-/**
- * Create a copy of an NPM package.json object, but with some or all of its
- * dependencies overriden according to the given override map.
- */
-function overrideNpmDependencies(
-    packageJson: NpmPackageJson,
-    overrides: PackageDependencyMap): NpmPackageJson {
-  return {
-    ...packageJson,
-    dependencies: {
-      ...packageJson.dependencies,
-      ...overrides,
+export interface ServerPlan {
+  /** The benchmarks this server will handle. */
+  specs: BenchmarkSpec[];
+  /** NPM installations needed for this server. */
+  npmInstalls: NpmInstall[];
+  /** URL to disk path mappings. */
+  mountPoints: MountPoint[];
+}
+
+export interface NpmInstall {
+  installDir: string;
+  packageJson: NpmPackageJson;
+}
+
+export async function makeServerPlans(
+    benchmarkRoot: string, specs: BenchmarkSpec[]): Promise<ServerPlan[]> {
+  const keySpecs = new Map<string, BenchmarkSpec[]>();
+  const keyDeps = new Map<string, PackageDependencyMap>();
+  const defaultSpecs = [];
+  for (const spec of specs) {
+    if (spec.url !== undefined) {
+      // No server needed for remote URLs.
+      continue;
     }
-  };
+    if (spec.version.label === 'default') {
+      defaultSpecs.push(spec);
+      continue;
+    }
+
+    const key = JSON.stringify([spec.implementation, spec.version.label]);
+    let arr = keySpecs.get(key);
+    if (arr === undefined) {
+      arr = [];
+      keySpecs.set(key, arr);
+    }
+    arr.push(spec);
+
+    const originalPackageJsonPath =
+        path.join(benchmarkRoot, spec.implementation, 'package.json');
+    const originalPackageJson = await fsExtra.readJson(originalPackageJsonPath);
+    const newDeps = {
+      ...originalPackageJson.dependencies,
+      ...spec.version.dependencyOverrides,
+    };
+    keyDeps.set(key, newDeps);
+  }
+
+  const plans = [];
+
+  if (defaultSpecs.length > 0) {
+    plans.push({
+      specs: defaultSpecs,
+      npmInstalls: [],
+      mountPoints: [],
+    });
+  }
+
+  for (const [key, specs] of keySpecs.entries()) {
+    const [implementation, label] = JSON.parse(key);
+    const dependencies = keyDeps.get(key);
+    if (dependencies === undefined) {
+      throw new Error(`Internal error: no deps for key ${key}`);
+    }
+
+    const originalPackageDir = path.join(benchmarkRoot, implementation);
+
+    const installDir = path.join(originalPackageDir, 'versions', label);
+    plans.push({
+      specs,
+      npmInstalls: [{
+        installDir,
+        packageJson: {
+          private: true,
+          dependencies,
+        }
+      }],
+      mountPoints: [
+        {
+          urlPath:
+              `/benchmarks/${implementation}/versions/${label}/node_modules`,
+          diskPath: path.join(installDir, 'node_modules'),
+        },
+        {
+          urlPath: `/benchmarks/${implementation}/versions/${label}`,
+          diskPath: path.join(benchmarkRoot, implementation),
+        }
+      ],
+    });
+  }
+
+  return plans;
 }
 
 /**
@@ -99,35 +177,22 @@ async function npmInstall(cwd: string): Promise<void> {
 }
 
 /**
- * Set up all <implementation>/version/<label> directories by copying the parent
- * package.json, applying dependency overrides to it, and running "npm install".
+ * Set up an <implementation>/version/<label> directory by copying the parent
+ * package.json, applying dependency overrides to it, and running "npm
+ * install".
  */
-export async function prepareVersionDirectories(
-    benchmarksDir: string, specs: BenchmarkSpec[]): Promise<void> {
-  for (const spec of specs) {
-    if (spec.version.label === 'default') {
-      // This is just the main implementation installation. We assume it's
-      // already been setup by the main npm install process.
-      continue;
-    }
-    const implDir = path.join(benchmarksDir, spec.implementation);
-    const versionDir = path.join(implDir, 'versions', spec.version.label);
-    if (await fsExtra.pathExists(versionDir)) {
-      // TODO(aomarks) If the user specified new dependencies for the same
-      // version label, it probably makes sense to delete the version directory
-      // and install it again. We could read the package.json and check if the
-      // versions differ.
-      continue;
-    }
-    console.log(`Installing ${spec.implementation}/${spec.version.label} ...`);
-    await fsExtra.ensureDir(versionDir);
-    const packageJson =
-        await fsExtra.readJson(path.join(implDir, 'package.json')) as
-        NpmPackageJson;
-    const newPackageJson =
-        overrideNpmDependencies(packageJson, spec.version.dependencyOverrides);
-    await fsExtra.writeJson(
-        path.join(versionDir, 'package.json'), newPackageJson, {spaces: 2});
-    await npmInstall(versionDir);
+export async function prepareVersionDirectory(
+    {installDir, packageJson}: NpmInstall): Promise<void> {
+  if (await fsExtra.pathExists(installDir)) {
+    // TODO(aomarks) If the user specified new dependencies for the same
+    // version label, it probably makes sense to delete the version directory
+    // and install it again. We could read the package.json and check if the
+    // versions differ.
+    return;
   }
+  console.log(`\nInstalling ${installDir} ...`);
+  await fsExtra.ensureDir(installDir);
+  await fsExtra.writeJson(
+      path.join(installDir, 'package.json'), packageJson, {spaces: 2});
+  await npmInstall(installDir);
 }


### PR DESCRIPTION
This PR does preparation work for dropping the implementation concept, and the file layout requirements, which will come in the next PR.

1) Previously we installed custom NPM package versions to:
  `<your project>/<implementation>/versions/<label>`

   Now we install to:
  `<system temp dir>/tachometer/versions/<sha256(implementation dir, label)>`

   This way we won't litter your directories with temporary files, which was already not great, but would be even worse when we're pointing tachometer at arbitrary directories on your system.

2) We now run a separate server for each custom NPM installation. With the fixed file layout, we could guarantee a unique URL path for each benchmark for each NPM installation, since we mount them to `/benchmarks/<implementation>/versions/<version>/<benchmark>`. But with arbitrary files, we also want matching arbitrary URL paths, so we won't have a unique URL path per NPM installation. Running a separate server for each NPM installation allows the same URL paths to be used, but with different underlying `node_modules/` directories mounted to each server.

3) Adds and tests a "server plan" abstraction, which configures the servers to run, the NPM installs we need for them, and the URL mounting scheme. This is just to make the code more clear and testable.